### PR TITLE
feat: Add XDG Base Directory Specification support

### DIFF
--- a/chromaterm/__main__.py
+++ b/chromaterm/__main__.py
@@ -73,6 +73,33 @@ def args_init(args=None):
     return parser.parse_args(args=args)
 
 
+def check_config_files(args):
+    """Checks for the existence of configuration files in the paths designated
+    by the XDG specification
+    """
+    # Paths where the configuration file might be
+    search_paths = [
+        '{}/chromaterm/chromaterm'.format(os.getenv('XDG_CONFIG_HOME', '~/.config')),
+        '~/Library/Preferences/chromaterm/chromaterm',
+        '~/.chromaterm',
+        '/etc/chromaterm/chromaterm',
+    ]
+
+    extensions = [
+        '.yaml',
+        '.yml',
+    ]
+
+    for path in search_paths:
+        for ext in extensions:
+            file = os.path.expanduser(path + ext)
+            if os.path.isfile(file):
+                args.config = file
+                break
+
+    return args
+
+
 def eprint(*args, **kwargs):
     """Prints a message to stderr."""
     print(sys.argv[0] + ':', *args, file=sys.stderr, **kwargs)
@@ -380,13 +407,14 @@ def main(args=None, max_wait=None, write_default=True):
         be used as sys.exit(chromaterm.cli.main()).
     """
     args = args_init(args)
+    args = check_config_files(args)
 
     if args.reload:
         return 'Processes reloaded: ' + str(reload_chromaterm_instances())
 
     if write_default:
         # Write default config if not there
-        write_default_config()
+        write_default_config(args=args)
 
     config = Config()
 

--- a/chromaterm/default_config.py
+++ b/chromaterm/default_config.py
@@ -87,24 +87,30 @@ def generate_default_rules_yaml():
     return data
 
 
-def write_default_config(directory=None, name=None):
+def write_default_config(directory=None, name=None, args=None):
     """Writes the default configuration file if it doesn't exist.
 
     Args:
         directory (str): The directory where the file should be placed. Defaults
             to the home directory of the user.
         name (str): The name of the file. Defaults to '.chromaterm.yml'
+        args (str): The script arguments. If given, the specified file is used
+            instead of the aforementioned arguments
 
     Returns:
         True if a file was written. False otherwise.
     """
-    if not directory:
-        directory = os.path.expanduser('~')
+    if not args or not args.config:
+        if not directory:
+            directory = os.path.expanduser('~')
 
-    if not name:
-        name = '.chromaterm.yml'
+        if not name:
+            name = '.chromaterm.yml'
 
-    location = os.path.join(directory, name)
+        location = os.path.join(directory, name)
+
+    else:
+        location = args.config
 
     # Already exists
     if os.access(location, os.F_OK):


### PR DESCRIPTION
This enables XDG support as well as a few other places in which the configuration file can be located. These are as follows :

- `${XDG_CONFIG_HOME}` — if available, falling back to `~/.config` otherwise.
- `~/Library/Preferences/chromaterm/chromaterm` in MacOS.
- The default `~/.chromaterm.yml`
- A system-wide `/etc/chromaterm/chromaterm.yml`

The file extensions can now also be `yml` as well as `yaml`.

Forgive my rusty python and feel free to point me towards any change that you might want incorporated.